### PR TITLE
add `wait-for-postgres` script and complete `npm run dev`

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -1,5 +1,6 @@
 services:
   database:
+    container_name: "postgres-dev"
     image: "postgres:16.0-alpine3.18"
     env_file:
       - ../.env.development

--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,0 +1,16 @@
+const { exec } = require("node:child_process");
+
+function checkPostgres() {
+  exec("docker exec postgres-dev pg_isready --host localhost", handleReturn);
+
+  function handleReturn(error, stdout) {
+    if (stdout.search("accepting connections") === -1) {
+      process.stdout.write(".");
+      checkPostgres();
+      return;
+    }
+    console.log("\n🎯 PgSQL is ready!\n");
+  }
+}
+console.log("\n🏃💨 Waiting PgSQL is ready for conections...");
+checkPostgres();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "npm run services:up && next dev",
+    "dev": "npm run services:up && npm run wait-for-postgres && npm run migration:up && next dev",
     "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",
     "services:down": "docker compose -f infra/compose.yaml down",
@@ -13,7 +13,8 @@
     "test": "jest --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "migration:create": "node-pg-migrate --migrations-dir infra/migrations create",
-    "migration:up": "node-pg-migrate --migrations-dir infra/migrations --envPath .env.development up"
+    "migration:up": "node-pg-migrate --migrations-dir infra/migrations --envPath .env.development up",
+    "wait-for-postgres": "node infra/scripts/wait-for-postgres.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Add a `wait-for-postgres` script to migrations can be executed on command npm run dev