### PR TITLE
Padronização dos controllers

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(resquest, response) {
+  const publicError = new MethodNotAllowedError();
+  response.status(publicError.statusCode).json(publicError);
+}
+
+function onErrorHandler(error, resquest, response) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+    statusCode: error.statusCode,
+  });
+  console.error(publicErrorObject);
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  onErrorHandler,
+  onNoMatchHandler,
+  errorsHandler: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,5 +1,5 @@
 import { Client } from "pg";
-
+import { ServicesError } from "./errors.js";
 async function query(pedido) {
   let client;
   try {
@@ -7,10 +7,11 @@ async function query(pedido) {
     const res = await client.query(pedido);
     return res;
   } catch (err) {
-    console.log("\nErro no database.js:\n");
-    console.error(err);
-    console.log("\n\n");
-    throw err;
+    const serviceError = new ServicesError({
+      message: "Erro na conexão do banco de dados ou query",
+      cause: err,
+    });
+    throw serviceError;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,11 +1,44 @@
 export class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", { cause });
     this.name = "InternalServerError";
     this.action = "Entre em contato com o Suporte";
-    this.statusCode = "500";
+    this.statusCode = statusCode || 500;
   }
 
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método de requisição não permitido.");
+    this.name = "MethodNotAllowedError";
+    this.action = "Verifique se o método HTTP é valido para este endpoint.";
+    this.statusCode = 405;
+  }
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+export class ServicesError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento", { cause });
+    this.name = "ServicesError";
+    this.action = "Verifique se o serviço está disponível no momento.";
+    this.statusCode = 503;
+  }
   toJSON() {
     return {
       name: this.name,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2118,6 +2119,11 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -9013,6 +9019,18 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10127,6 +10145,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,51 +1,53 @@
 import migrationRunner from "node-pg-migrate";
 import { resolve } from "node:path";
 import database from "infra/database";
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
 
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "{$request.method}" not allowed`,
-    });
-  }
+const router = createRouter();
+router.get(getHandler).post(postHandler);
+
+export default router.handler(controller.errorsHandler);
+
+const deafultMigrationsOptions = {
+  dir: resolve("infra", "migrations"),
+  dryRun: false,
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function getHandler(request, response) {
   let dbClient;
   try {
     dbClient = await database.getNewClient();
 
-    const deafultMigrationsOptions = {
-      dbClient: dbClient,
-      dir: resolve("infra", "migrations"),
-      dryRun: false,
-      direction: "up",
-      verbose: true,
-      migrationsTable: "pgmigrations",
-    };
+    const pendingMigrations = await migrationRunner({
+      ...deafultMigrationsOptions,
+      dryRun: true,
+      dbClient,
+    });
 
-    // Caso o metodo seja POST mostra e executa as migrações
-    if (request.method === "POST") {
-      const migratedMigrations = await migrationRunner({
-        ...deafultMigrationsOptions,
-      });
+    return response.status(200).json(pendingMigrations);
+  } finally {
+    await dbClient.end();
+  }
+}
 
-      if (migratedMigrations.length > 0) {
-        return response.status(201).json(migratedMigrations);
-      }
-      return response.status(200).json(migratedMigrations);
+async function postHandler(request, response) {
+  let dbClient;
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...deafultMigrationsOptions,
+      dbClient,
+    });
+
+    if (migratedMigrations.length > 0) {
+      return response.status(201).json(migratedMigrations);
     }
-
-    // Caso for GET, mostra as migrações pendentes
-    if (request.method === "GET") {
-      const pendingMigrations = await migrationRunner({
-        ...deafultMigrationsOptions,
-        dryRun: true,
-      });
-
-      return response.status(200).json(pendingMigrations);
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    return response.status(200).json(migratedMigrations);
   } finally {
     await dbClient.end();
   }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,47 +1,43 @@
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors.js";
+import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
 
-async function status(request, response) {
-  try {
-    const dateNow = new Date().toISOString();
+const router = createRouter();
 
-    //Faz a query e recebe as informações de versão
-    const databaseVersionResponse = await database.query(
-      "SHOW server_version;",
-    );
-    const databaseVersionValue = databaseVersionResponse.rows[0].server_version;
+router.get(getHandler);
 
-    //Faz a query e recebe as informações de max_connections depois de tratar
-    const databaseMaxConnectionsResponse = await database.query(
-      "SHOW max_connections;",
-    );
-    const databaseMaxConnectionsValue =
-      databaseMaxConnectionsResponse.rows[0].max_connections;
+export default router.handler(controller.errorsHandler);
 
-    //Faz a query e recebe as informações de connections ativas
-    const databaseName = process.env.POSTGRES_DB;
-    const databaseOpendConnectionsResponse = await database.query({
-      text: "SELECT count(*)::int from pg_stat_activity WHERE datname = $1",
-      values: [databaseName],
-    });
-    const userConnectionsRows = databaseOpendConnectionsResponse.rows[0].count;
+async function getHandler(request, response) {
+  const dateNow = new Date().toISOString();
 
-    response.status(200).json({
-      updated_at: dateNow,
-      dependecies: {
-        database: {
-          version: databaseVersionValue,
-          max_connections: parseInt(databaseMaxConnectionsValue),
-          opend_connections: userConnectionsRows,
-        },
+  //Faz a query e recebe as informações de versão
+  const databaseVersionResponse = await database.query("SHOW server_version;");
+  const databaseVersionValue = databaseVersionResponse.rows[0].server_version;
+
+  //Faz a query e recebe as informações de max_connections depois de tratar
+  const databaseMaxConnectionsResponse = await database.query(
+    "SHOW max_connections;",
+  );
+  const databaseMaxConnectionsValue =
+    databaseMaxConnectionsResponse.rows[0].max_connections;
+
+  //Faz a query e recebe as informações de connections ativas
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseOpendConnectionsResponse = await database.query({
+    text: "SELECT count(*)::int from pg_stat_activity WHERE datname = $1",
+    values: [databaseName],
+  });
+  const userConnectionsRows = databaseOpendConnectionsResponse.rows[0].count;
+
+  response.status(200).json({
+    updated_at: dateNow,
+    dependecies: {
+      database: {
+        version: databaseVersionValue,
+        max_connections: parseInt(databaseMaxConnectionsValue),
+        opend_connections: userConnectionsRows,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({ cause: error });
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObject);
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/v1/migrations/put.test.js
+++ b/tests/integration/v1/migrations/put.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+});
+
+describe("PUT api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("Returning method not allowed error", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "PUT",
+      });
+
+      const responseBody = await response.json();
+      expect(response.status).toBe(405);
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método de requisição não permitido.",
+        action: "Verifique se o método HTTP é valido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});

--- a/tests/integration/v1/status/post.test.js
+++ b/tests/integration/v1/status/post.test.js
@@ -1,0 +1,25 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Returning method not allowed error", async () => {
+      // Verifica se a aplicação está viva
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      const responseBody = await response.json();
+
+      expect(response.status).toBe(405);
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método de requisição não permitido.",
+        action: "Verifique se o método HTTP é valido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Padronizado os Controllers dos endpoint `/migrations` e `/status`
Adiciona 2 novos erros customizados: `ServicesError` e `MethodNotAllowedError`
Faz o `InternalServerError` aceitar injeção de `statusCode`